### PR TITLE
Add number of followers, change layout to fit all informations in one…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "paper-item": "PolymerElements/paper-item#^1.2.2",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.6",
     "paper-menu": "PolymerElements/paper-menu#^1.3.0",
+    "paper-tooltip": "PolymerElements/paper-tooltip#^1.1.4",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.7"
   },
   "devDependencies": {

--- a/requirements-grid.html
+++ b/requirements-grid.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-item/paper-item.html">
 <link rel="import" href="../paper-menu/paper-menu.html">
+<link rel="import" href="../paper-tooltip/paper-tooltip.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-icons/editor-icons.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
@@ -96,7 +97,7 @@ Example:
         padding: 0px 0px;
       }
 
-      .card-actions > paper-button {
+      .card-actions > span > paper-button {
         margin: 0 auto;
         min-width: 2em;
         padding: 0.8em 0.25em;
@@ -165,22 +166,34 @@ Example:
               </time>
               <div class="card-content truncate">{{item.description}}</div>
               <div class="card-actions">
-                <paper-button noink>
-                  <iron-icon icon="star"></iron-icon>
-                  {{item.upVotes}}
-                </paper-button>
-                <paper-button noink>
-                  <iron-icon icon="book"></iron-icon>
-                  {{item.numberOfFollowers}}
-                </paper-button>
-                <paper-button noink>
-                  <iron-icon icon="question-answer"></iron-icon>
-                  {{item.numberOfComments}}
-                </paper-button>
-                <paper-button noink>
-                  <iron-icon icon="editor:attach-file"></iron-icon>
-                  {{item.numberOfAttachments}}
-                </paper-button>
+                <span>
+                  <paper-button noink>
+                    <iron-icon icon="star"></iron-icon>
+                    {{item.upVotes}}
+                  </paper-button>
+                  <paper-tooltip>Number of Votes</paper-tooltip>
+                </span>
+                <span>
+                  <paper-button noink>
+                    <iron-icon icon="bookmark"></iron-icon>
+                    {{item.numberOfFollowers}}
+                  </paper-button>
+                  <paper-tooltip>Number of Followers</paper-tooltip>
+                </span>
+                <span>
+                  <paper-button noink>
+                    <iron-icon icon="question-answer"></iron-icon>
+                    {{item.numberOfComments}}
+                  </paper-button>
+                  <paper-tooltip>Number of Comments</paper-tooltip>
+                </span>
+                <span>
+                  <paper-button noink>
+                    <iron-icon icon="editor:attach-file"></iron-icon>
+                    {{item.numberOfAttachments}}
+                  </paper-button>
+                  <paper-tooltip>Number of Attachments</paper-tooltip>
+                </span>
               </div>
             </paper-card>
           </div>

--- a/requirements-grid.html
+++ b/requirements-grid.html
@@ -92,16 +92,18 @@ Example:
       }
 
       .card-actions {
-        text-align:center;
+        text-align: center;
+        padding: 0px 0px;
       }
 
       .card-actions > paper-button {
         margin: 0 auto;
-        min-width: 4em;
+        min-width: 2em;
+        padding: 0.8em 0.25em;
       }
 
       .card-actions > paper-button > iron-icon {
-        margin-right: 0.3em;
+        margin-right: 0.2em;
       }
     </style>
 
@@ -164,12 +166,16 @@ Example:
               <div class="card-content truncate">{{item.description}}</div>
               <div class="card-actions">
                 <paper-button noink>
-                  <iron-icon icon="question-answer"></iron-icon>
-                  {{item.numberOfComments}}
-                </paper-button>
-                <paper-button noink>
                   <iron-icon icon="star"></iron-icon>
                   {{item.upVotes}}
+                </paper-button>
+                <paper-button noink>
+                  <iron-icon icon="book"></iron-icon>
+                  {{item.numberOfFollowers}}
+                </paper-button>
+                <paper-button noink>
+                  <iron-icon icon="question-answer"></iron-icon>
+                  {{item.numberOfComments}}
                 </paper-button>
                 <paper-button noink>
                   <iron-icon icon="editor:attach-file"></iron-icon>

--- a/requirements-grid.html
+++ b/requirements-grid.html
@@ -171,28 +171,28 @@ Example:
                     <iron-icon icon="star"></iron-icon>
                     {{item.upVotes}}
                   </paper-button>
-                  <paper-tooltip>Number of Votes</paper-tooltip>
+                  <paper-tooltip>Votes</paper-tooltip>
                 </span>
                 <span>
                   <paper-button noink>
                     <iron-icon icon="bookmark"></iron-icon>
                     {{item.numberOfFollowers}}
                   </paper-button>
-                  <paper-tooltip>Number of Followers</paper-tooltip>
+                  <paper-tooltip>Followers</paper-tooltip>
                 </span>
                 <span>
                   <paper-button noink>
                     <iron-icon icon="question-answer"></iron-icon>
                     {{item.numberOfComments}}
                   </paper-button>
-                  <paper-tooltip>Number of Comments</paper-tooltip>
+                  <paper-tooltip>Comments</paper-tooltip>
                 </span>
                 <span>
                   <paper-button noink>
                     <iron-icon icon="editor:attach-file"></iron-icon>
                     {{item.numberOfAttachments}}
                   </paper-button>
-                  <paper-tooltip>Number of Attachments</paper-tooltip>
+                  <paper-tooltip>Attachments</paper-tooltip>
                 </span>
               </div>
             </paper-card>


### PR DESCRIPTION
… row #RB-543 

Only a very small pull request to show number of followers for each requirement. I tested the layout for double numbers for all attributes. 99 votes, 99 followers, 99 comments, 99 attachments, still works fine in one row. Bigger numbers needs of course than 2 rows.